### PR TITLE
Issue #17: Adjust geocoder search placeholder text

### DIFF
--- a/src/components/MapPanel.vue
+++ b/src/components/MapPanel.vue
@@ -33,6 +33,7 @@ export default {
     map.addControl(
       new MapboxGeocoder({
         accessToken: mapboxgl.accessToken,
+        placeholder: 'Search for a nearby town',
         mapboxgl,
       }),
     );


### PR DESCRIPTION
Found placeholder param in https://github.com/mapbox/mapbox-gl-geocoder/blob/master/API.md. Thanks for the hint in the issue. 

Verified by running the app. 

LMK if you'd like this to be a constant or if hardcoding it is OK. 