### PR TITLE
Issue #32: make search text size for mobile smaller

### DIFF
--- a/src/components/MapPanel.vue
+++ b/src/components/MapPanel.vue
@@ -260,6 +260,16 @@ export default {
 };
 </script>
 
+<style>
+/* 
+  Overrride the size of Search placeholder text.
+  Otherwise it will be 18px for screens liss wide than 640px.
+*/
+#map-panel.panel.mapboxgl-map .mapboxgl-ctrl-geocoder.mapboxgl-ctrl .mapboxgl-ctrl-geocoder--input {
+  font-size: 15px;
+}
+</style>
+
 <style scoped>
 #map-panel {
   height: 400px;


### PR DESCRIPTION
The problem was that the geocoder search input box inherits the 18px (too-large-for-mobile) font from a paren element, but has a conditional override to make that font 15px for screens wider than 640px. 

So I made it always use 15px for that search box.  

<img width="332" alt="Screen Shot 2020-10-30 at 10 14 15 PM" src="https://user-images.githubusercontent.com/5553491/97771752-5f215480-1afd-11eb-8103-a569bca08739.png">
<img width="806" alt="Screen Shot 2020-10-30 at 10 14 39 PM" src="https://user-images.githubusercontent.com/5553491/97771753-621c4500-1afd-11eb-83f6-964092c070a9.png">
